### PR TITLE
composer で install 可能にする設定

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "name": "zengin-code/source-data",
+  "description": "Source data of the zengin-code for JSON & YAML",
+  "license": "MIT"
+}


### PR DESCRIPTION
[composer](https://getcomposer.org/) を使用し、 `zengin-code/source-data` を取得する為の設定。

以下のイメージで `composer.json` に追記し、 composer install / update で引き込む。

```
  {
    "require": {
+     "zengin-code/source-data": "*"
    }
  }
```

git submodule で取得するようにしたかったが、 composer install や update の際に引き込む術が無い為。
